### PR TITLE
Extend budget size to fix docker build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -48,13 +48,13 @@
                             "budgets": [
                                 {
                                     "type": "initial",
-                                    "maximumWarning": "500kb",
-                                    "maximumError": "1mb"
+                                    "maximumWarning": "4mb",
+                                    "maximumError": "5mb"
                                 },
                                 {
                                     "type": "anyComponentStyle",
-                                    "maximumWarning": "2kb",
-                                    "maximumError": "4kb"
+                                    "maximumWarning": "4mb",
+                                    "maximumError": "5mb"
                                 }
                             ],
                             "fileReplacements": [


### PR DESCRIPTION
this patch will fix the following error message:
![image](https://github.com/ETIMS-Inc/etims-web/assets/43444946/61514cd4-c4af-4f84-b5db-cb233256e06d)
